### PR TITLE
Merge images not loading bugfix into master.

### DIFF
--- a/app/controllers/slideshows_controller.rb
+++ b/app/controllers/slideshows_controller.rb
@@ -13,7 +13,7 @@ class SlideshowsController < ApplicationController
 
     # whats_hot = Slideshow.whats_hot_slideshow
 
-    @channels = Slideshow.whats_hot_slideshow.results.order(created_at: :desc).map { |d| {thumb: d.thumb, uuid: d.uuid} }.compact # change .results to .nsfw for mature filter.
+    @channels = Slideshow.whats_hot_slideshow.results.order(created_at: :desc).map { |d| {thumb: d.thumb.sub!(/https/, 'http'), uuid: d.uuid} }.compact # change .results to .nsfw for mature filter.
 
     # If a slideshow doesn't exist for a given seed, having it show up in the channel changer will produce errors if it's
     # selected as the user's channel. This happens when What's Hot has been updated, but before all the MLT results have been
@@ -69,10 +69,10 @@ class SlideshowsController < ApplicationController
         url_hash = { seed: seed_in_db }
         first_deviation = Deviation.where(uuid: seed_in_db).first
 
-        url_hash[0] = { url: first_deviation.src, title: first_deviation.title, author: first_deviation.author, link: first_deviation.url } if first_deviation
+        url_hash[0] = { url: first_deviation.src.sub(/https/, 'http'), title: first_deviation.title, author: first_deviation.author, link: first_deviation.url } if first_deviation
 
         deviations = current_user.slideshow.results # add .where(mature: false) for mature filter.
-        urls = deviations.map { |d| { url: d.src, title: d.title, author: d.author, link: d.url } }.compact
+        urls = deviations.map { |d| { url: d.src.sub(/https/, 'http'), title: d.title, author: d.author, link: d.url } }.compact
 
         urls.each_with_index do |u,i|
           if first_deviation

--- a/app/helpers/api_helper.rb
+++ b/app/helpers/api_helper.rb
@@ -120,8 +120,8 @@ module ApiHelper
       author = entry["author"]["username"]
       mature = entry["is_mature"]
       uuid = entry["deviationid"]
-      src = entry["content"]["src"].sub(/http:/, "https:")
-      thumb = entry["thumbs"].last["src"].sub(/http:/, "https:")
+      src = entry["content"]["src"]
+      thumb = entry["thumbs"].last["src"]
 
       # We don't need height and width on their own, but it makes
       # the orientation calculation easier to read. Might be interesting

--- a/app/models/deviation.rb
+++ b/app/models/deviation.rb
@@ -1,7 +1,7 @@
 class Deviation < ActiveRecord::Base
 
   DA_URL_REGEX = /http:\/\/.*\.deviantart\.(com|net)/
-  DA_IMAGE_REGEX = /https:\/\/.*\.deviantart\.(com|net).*(jpg|png|gif)/
+  DA_IMAGE_REGEX = /https?:\/\/.*\.deviantart\.(com|net).*(jpg|png|gif)/
 
   # Validations:
   validates :url, presence: true, format: DA_URL_REGEX


### PR DESCRIPTION
DA doesn't like loading a significant number of it's images over https for some reason. They just time out, either in a slideshow or in the channel changer. 

These commits make sure every DA image url sent to the browser is http, removes the https requirement from the model validation for url strings, and removes the forced saving of urls to the database in https format.